### PR TITLE
fix: Arreglo de fallo de dependencias para actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-nose==1.4.6
 django-rest-swagger==2.2.0
 selenium==4.7.2
 pynose==1.4.8
-numpy==1.26.2
-pandas==2.1.3
-ldap3==2.9.1
+numpy
+pandas
+ldap3
 python-decouple==3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-nose==1.4.6
 django-rest-swagger==2.2.0
 selenium==4.7.2
 pynose==1.4.8
-numpy
-pandas
-ldap3
+numpy==1.24.4
+pandas==2.0.3
+ldap3==2.9.1
 python-decouple==3.8


### PR DESCRIPTION
Se han cambiado las versiones de numpy, pandas y ldap3, previamente solo instalables en python 3.10, para acomodar las versiones de pruebas de github actions de python 3.8 y 3.9.

Closes #211